### PR TITLE
Fixed gremlin with new tags

### DIFF
--- a/gremlin/assertionchecker_a8.py
+++ b/gremlin/assertionchecker_a8.py
@@ -168,9 +168,9 @@ class A8AssertionChecker(object):
         # if self.time_range:
         #     body["filter"] = {"range" : self.time_range}
         if src:
-            body["query"]["bool"]["must"].append({"prefix": {"src": src}})
+            body["query"]["bool"]["must"].append({"match": {"src": src}})
         if dst:
-            body["query"]["bool"]["must"].append({"prefix": {"dst": dst}})
+            body["query"]["bool"]["must"].append({"match": {"dst": dst}})
         return body
 
     def check_bounded_response_time(self, **kwargs):
@@ -249,9 +249,9 @@ class A8AssertionChecker(object):
                     "filter": {
                         "bool": {
                             "must": [
-                                {"term": {"src": source}},
-                                {"prefix": {"dst": dest}},
-                                { "term": {self.trace_log_key: self.trace_log_value}}
+                                {"match": {"src": source}},
+                                {"match": {"dst": dest}},
+                                {"term": {self.trace_log_key: self.trace_log_value}}
                             ]
                         }
                     }
@@ -313,8 +313,8 @@ class A8AssertionChecker(object):
                     "filter": {
                         "bool": {
                             "must": [
-                                {"term": {"src": source}},
-                                {"prefix": {"dst": dest}},
+                                {"match": {"src": source}},
+                                {"match": {"dst": dest}},
                                 {"match": {self.trace_log_key: self.trace_log_value}}
                             ]
                         }

--- a/gremlin/failuregenerator_a8.py
+++ b/gremlin/failuregenerator_a8.py
@@ -8,6 +8,7 @@ import logging
 import httplib
 import re
 import datetime, time
+import sys
 logging.basicConfig()
 requests_log = logging.getLogger("requests.packages.urllib3")
 


### PR DESCRIPTION
ElasticSearch's prefix query breaks when you try to use an equal sign. Match still works.

Also added a missing import.